### PR TITLE
Update Dockerfile and GitHub Actions tags to digests

### DIFF
--- a/.github/workflows/build-binary-signed-ghat-malicious.yml
+++ b/.github/workflows/build-binary-signed-ghat-malicious.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: The malicious step
         run: |
           echo "// This is a malicious update" >> main.go
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5
         with:
           go-version: '1.21'
 
@@ -28,12 +28,12 @@ jobs:
           go build -v -o demo-repo-go-binary ./...
 
       - name: Sign artifact
-        uses: actions/attest-build-provenance@v1.0.0
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
         with:
           subject-path: '${{ github.workspace }}/demo-repo-go-binary'
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
         with:
           name: demo-repo-go-binary
           path: demo-repo-go-binary

--- a/.github/workflows/build-binary-signed-ghat.yml
+++ b/.github/workflows/build-binary-signed-ghat.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5
         with:
           go-version: '1.21'
 
@@ -24,12 +24,12 @@ jobs:
           go build -v -o demo-repo-go-binary ./...
 
       - name: Sign artifact
-        uses: actions/attest-build-provenance@v1.0.0
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
         with:
           subject-path: '${{ github.workspace }}/demo-repo-go-binary'
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
         with:
           name: demo-repo-go-binary
           path: demo-repo-go-binary

--- a/.github/workflows/build-binary-unsigned.yml
+++ b/.github/workflows/build-binary-unsigned.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5
         with:
           go-version: '1.21'
 
@@ -29,7 +29,7 @@ jobs:
 #          subject-path: '${{ github.workspace }}/demo-repo-go-binary'
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
         with:
           name: demo-repo-go-binary
           path: demo-repo-go-binary

--- a/.github/workflows/build-image-signed-cosign-malicious.yml
+++ b/.github/workflows/build-image-signed-cosign-malicious.yml
@@ -24,7 +24,7 @@ jobs:
           echo "// This is a malicious update" >> main.go
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.3.0
+        uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # v3.3.0
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf

--- a/.github/workflows/build-image-signed-cosign-static-copied.yml
+++ b/.github/workflows/build-image-signed-cosign-static-copied.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.3.0
+        uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # v3.3.0
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf

--- a/.github/workflows/build-image-signed-cosign-static.yml
+++ b/.github/workflows/build-image-signed-cosign-static.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.3.0
+        uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # v3.3.0
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf

--- a/.github/workflows/build-image-signed-cosign.yml
+++ b/.github/workflows/build-image-signed-cosign.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.3.0
+        uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # v3.3.0
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf

--- a/.github/workflows/build-image-signed-ghat-malicious.yml
+++ b/.github/workflows/build-image-signed-ghat-malicious.yml
@@ -34,7 +34,7 @@ jobs:
           context: .
 
       - name: Attest image
-        uses: actions/attest-build-provenance@v1.0.0
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push-step.outputs.digest }}

--- a/.github/workflows/build-image-signed-ghat-static-copied.yml
+++ b/.github/workflows/build-image-signed-ghat-static-copied.yml
@@ -31,7 +31,7 @@ jobs:
           file : Dockerfile.static
 
       - name: Attest image
-        uses: actions/attest-build-provenance@v1.0.0
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push-step.outputs.digest }}

--- a/.github/workflows/build-image-signed-ghat-static.yml
+++ b/.github/workflows/build-image-signed-ghat-static.yml
@@ -31,7 +31,7 @@ jobs:
           file : Dockerfile.static
 
       - name: Attest image
-        uses: actions/attest-build-provenance@v1.0.0
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push-step.outputs.digest }}

--- a/.github/workflows/build-image-signed-ghat.yml
+++ b/.github/workflows/build-image-signed-ghat.yml
@@ -30,7 +30,7 @@ jobs:
           context: .
 
       - name: Attest image
-        uses: actions/attest-build-provenance@v1.0.0
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push-step.outputs.digest }}

--- a/.github/workflows/frizbee-action.yml
+++ b/.github/workflows/frizbee-action.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: stacklok/frizbee-action@v0.0.1
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: stacklok/frizbee-action@327fadceec41e0489482b0493648a9075d4bc161 # v0.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.FRIZZBEE_TOKEN }}
         with:

--- a/.github/workflows/frizbee.yml
+++ b/.github/workflows/frizbee.yml
@@ -9,7 +9,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/first-interaction@v1
+    - uses: actions/first-interaction@fb2402657b4a28582200150d0a145671d0e50597 # v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: "Message that will be displayed on users' first issue"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine
+FROM index.docker.io/library/golang:1.20-alpine@sha256:e47f121850f4e276b2b210c56df3fda9191278dd84a3a442bfe0b09934462a8f
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR changes the projects Dockerfile and GitHub Actions tags to digests.

For more details, refer to the [GitHubs documentation on security hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

To automate this process and keep up to date, you could also use [Minder](https://cloud.stacklok.com), an open-source DevSecOps platform. Stacklok offers a free-for-open-source hosted version.

Full disclosure: I am an open source dev working at Stacklok on the [Minder Open source project](https://github.com/stacklok/minder), aiming to help secure the open source software.

If you don't feel you need this, please just go ahead and close and I will not bother you again.
